### PR TITLE
Plotly 化: 日報・時間別・月別分析グラフのインタラクティブ表示

### DIFF
--- a/src/components/charts/DailyReportAnalysisCharts.py
+++ b/src/components/charts/DailyReportAnalysisCharts.py
@@ -1,6 +1,4 @@
 import streamlit as st
-import matplotlib.pyplot as plt
-from matplotlib.ticker import FuncFormatter
 import numpy as np
 import plotly.graph_objects as go
 
@@ -11,128 +9,231 @@ class DailyReportAnalysisCharts:
     '''
     日報分析クラス用の画像生成クラス
     '''
-    def currency_formatter(self, 
-                           x, 
-                           _):
-        return f'¥{int(x):,}'
-    
-    def customer_formatter(self, 
-                        x, 
-                        _):
-        return f'{int(x):,}人'
 
-    def lunch_night_stacked_bar(self, 
-                                df, 
-                                str1, 
-                                str2, 
-                                str3):
-        fig, ax = plt.subplots(figsize=(20, 12))
-        plt.bar(df.index, df[str1], align="center", color='darkorange', label=str1, width=0.5)
-        plt.bar(df.index, df[str2], bottom=df[str1], align="center", color='royalblue', label=str2, width=0.5)
-        plt.legend(loc="upper right", fontsize=10)
-        ax.set_axisbelow(True)
-        plt.xticks(rotation=90)
+    def _stacked_hover_suffix(self, str2: str) -> str:
         if '売上' in str2:
-            plt.yticks(np.arange(0, 370001, 25000),fontsize=15)
-            plt.ylim(0, 370000)
-            plt.axhline(y=200000, xmin=0, xmax=len(df.index), color='r')
-            plt.axhline(y=100000, xmin=0, xmax=len(df.index), color='black')
-            plt.gca().yaxis.set_major_formatter(FuncFormatter(self.currency_formatter))
+            return '¥%{y:,.0f}'
+        if '客数' in str2:
+            return '%{y:,.0f}人'
+        return '¥%{y:,.0f}'
+
+    def lunch_night_stacked_bar(self,
+                                df,
+                                str1,
+                                str2,
+                                str3):
+        x_vals = [str(i) for i in df.index]
+        ht_suffix = self._stacked_hover_suffix(str2)
+        fig = go.Figure()
+        fig.add_trace(go.Bar(
+            x=x_vals,
+            y=df[str1].tolist(),
+            name=str1,
+            marker_color='darkorange',
+            hovertemplate=f'日: %{{x}}<br>{str1}: {ht_suffix}<extra></extra>',
+        ))
+        fig.add_trace(go.Bar(
+            x=x_vals,
+            y=df[str2].tolist(),
+            name=str2,
+            marker_color='royalblue',
+            hovertemplate=f'日: %{{x}}<br>{str2}: {ht_suffix}<extra></extra>',
+        ))
+
+        if '売上' in str2:
+            y_max = 370000
+            tick_vals = list(np.arange(0, 370001, 25000))
+            fig.add_hline(y=200000, line_color='red', line_width=1)
+            fig.add_hline(y=100000, line_color='black', line_width=1)
+            y_tickformat = ',.0f'
+            y_tickprefix = '¥'
         elif '客数' in str2:
-            plt.yticks(np.arange(0, 201, 20),fontsize=15)
-            plt.ylim(0, 200)
-            plt.axhline(y=100, xmin=0, xmax=len(df.index), color='r')
+            y_max = 200
+            tick_vals = list(np.arange(0, 201, 20))
+            fig.add_hline(y=100, line_color='red', line_width=1)
+            y_tickformat = ',.0f'
+            y_tickprefix = ''
         else:
-            plt.ylim(0, 3000)
-            plt.yticks(np.arange(0, 3001, 500),fontsize=15)
-            plt.axhline(y=2000, xmin=0, xmax=len(df.index), color='r')
-            plt.gca().yaxis.set_major_formatter(FuncFormatter(self.currency_formatter))
-        ax.set(ylabel=str3)
-        plt.xticks(np.arange(0, len(df), 1), df.index, rotation=28)
-        plt.grid(axis='y')
-        st.pyplot(fig)
+            y_max = 3000
+            tick_vals = list(np.arange(0, 3001, 500))
+            fig.add_hline(y=2000, line_color='red', line_width=1)
+            y_tickformat = ',.0f'
+            y_tickprefix = '¥'
+
+        fig.update_layout(
+            barmode='stack',
+            yaxis=dict(
+                title=str3,
+                range=[0, y_max],
+                tickmode='array',
+                tickvals=tick_vals,
+                tickformat=y_tickformat,
+                tickprefix=y_tickprefix,
+                showgrid=True,
+                gridcolor='#e0e0e0',
+            ),
+            xaxis=dict(
+                title='日',
+                tickangle=-28,
+                type='category',
+            ),
+            legend=dict(
+                orientation='h',
+                yanchor='bottom',
+                y=1.02,
+                xanchor='right',
+                x=1,
+            ),
+            hovermode='x unified',
+            plot_bgcolor='white',
+            margin=dict(l=40, r=20, t=60, b=80),
+            height=520,
+        )
+        st.plotly_chart(fig, use_container_width=True)
 
     def daily_price_per_customer_bar(self,
                                      df
     ):
-        fig, ax = plt.subplots(figsize=(15, 3))
-        ax.set_axisbelow(True)
-        plt.bar(np.arange(0,len(df),1),df["1日客単価"],width=0.5
-                ,color="darkorange"
-                )
-        plt.ylim(0,3000)
-        plt.yticks(np.arange(0,3001,500))
-        plt.axhline (y=2000, xmin=0, xmax=len(df.index),color='r')
-        plt.gca().yaxis.set_major_formatter(FuncFormatter(self.currency_formatter))
-        plt.xticks(np.arange(0,len(df),1),df.index,rotation=28)
-        plt.grid(axis='y')        
-        st.pyplot(fig)
+        x_vals = [str(i) for i in df.index]
+        fig = go.Figure()
+        fig.add_trace(go.Bar(
+            x=x_vals,
+            y=df["1日客単価"].tolist(),
+            name='1日客単価',
+            marker_color='darkorange',
+            hovertemplate='日: %{x}<br>客単価: ¥%{y:,.0f}<extra></extra>',
+        ))
+        fig.add_hline(y=2000, line_color='red', line_width=1)
+        fig.update_layout(
+            yaxis=dict(
+                title='客単価 (¥)',
+                range=[0, 3000],
+                tickmode='array',
+                tickvals=list(np.arange(0, 3001, 500)),
+                tickformat=',.0f',
+                tickprefix='¥',
+                showgrid=True,
+                gridcolor='#e0e0e0',
+            ),
+            xaxis=dict(
+                title='日',
+                tickangle=-28,
+                type='category',
+            ),
+            showlegend=True,
+            legend=dict(orientation='h', y=1.02, x=1, xanchor='right', yanchor='bottom'),
+            hovermode='x unified',
+            plot_bgcolor='white',
+            margin=dict(l=40, r=20, t=60, b=80),
+            height=360,
+        )
+        st.plotly_chart(fig, use_container_width=True)
 
     def monthly_transfer_sum_bar(
             self,
             df_dic,
             str1
     ):
-        sum = []
+        sum_vals = []
         x_labels = []
-        fig, ax = plt.subplots(figsize=(20, 12))
-        ax.set_axisbelow(True)
-        # すべてのDataFrameにconvert_daily_report_dataを適用
         for year, months in df_dic.items():
             for month, df in months.items():
                 try:
-                    # DataFrameを変換
-                    sum.append(df_dic[year][month][str1].sum())
+                    sum_vals.append(df_dic[year][month][str1].sum())
                     x_labels.append(f"{year}/{month}({len(df_dic[year][month][str1])})")
                 except Exception as e:
                     print(f"エラーが発生しました: 年={year}, 月={month}, {e}")
-        sum_colors = ['#46bdc6']*(len(x_labels)-1)+['#ff6d01']
-        plt.bar(x_labels,sum,color=sum_colors,width=0.5)
-        plt.ticklabel_format(style='plain',axis='y')
-        plt.xticks(rotation=-90, fontsize=30)
-        plt.yticks(fontsize = 25)
-        if "売上" in str1 or "客単価" in str1 :
-            plt.gca().yaxis.set_major_formatter(FuncFormatter(self.currency_formatter))
-            plt.ylabel("月の総売上(円)", fontsize=40)
-        elif "客数" in str1:
-            plt.ylabel("月の総客数(人)", fontsize=40)
-            plt.gca().yaxis.set_major_formatter(FuncFormatter(self.customer_formatter))
-        plt.xlabel("年/月(営業日数)", fontsize=40)
-        plt.grid(axis='y', zorder=0)
-        st.pyplot(fig)
+        sum_colors = ['#46bdc6'] * (len(x_labels) - 1) + ['#ff6d01']
+
+        is_currency = "売上" in str1 or "客単価" in str1
+        if is_currency:
+            y_title = "月の総売上(円)"
+            hover_tmpl = '年月: %{x}<br>合計: ¥%{y:,.0f}<extra></extra>'
+            y_tickprefix = '¥'
+        else:
+            y_title = "月の総客数(人)"
+            hover_tmpl = '年月: %{x}<br>合計: %{y:,.0f}人<extra></extra>'
+            y_tickprefix = ''
+
+        fig = go.Figure()
+        fig.add_trace(go.Bar(
+            x=x_labels,
+            y=sum_vals,
+            name=str1,
+            marker_color=sum_colors,
+            hovertemplate=hover_tmpl,
+        ))
+        fig.update_layout(
+            xaxis=dict(title="年/月(営業日数)", tickangle=-90, tickfont=dict(size=14)),
+            yaxis=dict(
+                title=y_title,
+                tickformat=',.0f',
+                tickprefix=y_tickprefix,
+                tickfont=dict(size=14),
+                showgrid=True,
+                gridcolor='#e0e0e0',
+            ),
+            showlegend=True,
+            legend=dict(orientation='h', y=1.02, x=1, xanchor='right', yanchor='bottom'),
+            hovermode='x unified',
+            plot_bgcolor='white',
+            margin=dict(l=60, r=20, t=60, b=120),
+            height=560,
+        )
+        st.plotly_chart(fig, use_container_width=True)
 
     def monthly_transfer_mean_bar(
             self,
             df_dic,
             str1
     ):
-        mean = []
+        mean_vals = []
         x_labels = []
-        fig, ax = plt.subplots(figsize=(20, 12))
-        ax.set_axisbelow(True)
-        # すべてのDataFrameにconvert_daily_report_dataを適用
         for year, months in df_dic.items():
             for month, df in months.items():
                 try:
-                    # DataFrameを変換
-                    mean.append(df_dic[year][month][str1].mean())
+                    mean_vals.append(df_dic[year][month][str1].mean())
                     x_labels.append(f"{year}/{month}({len(df_dic[year][month][str1])})")
                 except Exception as e:
                     print(f"エラーが発生しました: 年={year}, 月={month}, {e}")
-        mean_colors = ['#46bdc6']*(len(x_labels)-1)+['#ff6d01']
-        plt.bar(x_labels,mean,color=mean_colors,width=0.5)
-        plt.ticklabel_format(style='plain',axis='y')
-        plt.xticks(rotation=-90, fontsize=30)
-        plt.yticks(fontsize = 25)
-        if "売上" in str1 or "客単価" in str1:
-            plt.gca().yaxis.set_major_formatter(FuncFormatter(self.currency_formatter))
-            plt.ylabel("月の総売上(円)", fontsize=40)
-        elif "客数" in str1:
-            plt.ylabel("月の総客数(人)", fontsize=40)
-            plt.gca().yaxis.set_major_formatter(FuncFormatter(self.customer_formatter))
-        plt.xlabel("年/月(営業日数)", fontsize=40)
-        plt.grid(axis='y', zorder=0)
-        st.pyplot(fig)
+        mean_colors = ['#46bdc6'] * (len(x_labels) - 1) + ['#ff6d01']
+
+        is_currency = "売上" in str1 or "客単価" in str1
+        if is_currency:
+            y_title = "月の総売上(円)"
+            hover_tmpl = '年月: %{x}<br>平均: ¥%{y:,.1f}<extra></extra>'
+            y_tickprefix = '¥'
+        else:
+            y_title = "月の総客数(人)"
+            hover_tmpl = '年月: %{x}<br>平均: %{y:,.1f}人<extra></extra>'
+            y_tickprefix = ''
+
+        fig = go.Figure()
+        fig.add_trace(go.Bar(
+            x=x_labels,
+            y=mean_vals,
+            name=str1,
+            marker_color=mean_colors,
+            hovertemplate=hover_tmpl,
+        ))
+        fig.update_layout(
+            xaxis=dict(title="年/月(営業日数)", tickangle=-90, tickfont=dict(size=14)),
+            yaxis=dict(
+                title=y_title,
+                tickformat=',.1f',
+                tickprefix=y_tickprefix,
+                tickfont=dict(size=14),
+                showgrid=True,
+                gridcolor='#e0e0e0',
+            ),
+            showlegend=True,
+            legend=dict(orientation='h', y=1.02, x=1, xanchor='right', yanchor='bottom'),
+            hovermode='x unified',
+            plot_bgcolor='white',
+            margin=dict(l=60, r=20, t=60, b=120),
+            height=560,
+        )
+        st.plotly_chart(fig, use_container_width=True)
 
 
     def weekly_comparison_bar(self, df1, df2, str1: str, date1: str, date2: str):
@@ -159,30 +260,22 @@ class DailyReportAnalysisCharts:
             offsetgroup=2  # バーをグループ化
         ))
 
-        # "売上" や "客単価" の場合は通貨フォーマット
+        yaxis_extra = {}
         if "売上" in str1 or "客単価" in str1:
-            fig.update_layout(
-                yaxis_tickformat="¥",  # 通貨のフォーマット
-                yaxis_title="月の総売上(円)",
-            )
-        # "客数" の場合は人数フォーマット
+            yaxis_extra = dict(tickprefix='¥', tickformat=',.0f', title="月の総売上(円)")
         elif "客数" in str1:
-            fig.update_layout(
-                yaxis_title="月の総客数(人)",
-            )
+            yaxis_extra = dict(tickformat=',.0f', ticksuffix='人', title="月の総客数(人)")
 
-        # x軸の設定 (日付ラベル、回転角度、フォントサイズ)
         fig.update_layout(
             xaxis=dict(
+                title="日付",
                 tickvals=np.arange(0, len(df1.index), 1),
                 ticktext=df1.index.tolist(),
                 tickfont=dict(size=15),
             ),
-            yaxis=dict(
-                tickfont=dict(size=15),
-            ),
+            yaxis=dict(tickfont=dict(size=15), **yaxis_extra),
             title=f'{date1}と{date2}の{str1}の曜日別比較',
-            barmode='group',  # バーをグループ化
+            barmode='group',
             showlegend=True,
             legend=dict(
                 title="月",
@@ -190,9 +283,9 @@ class DailyReportAnalysisCharts:
                 x=0.01,
                 y=0.99
             ),
-            xaxis_title="日付",
-            margin=dict(l=40, r=40, t=40, b=80),  # ラベルが切れないようにマージンを調整
+            margin=dict(l=40, r=40, t=40, b=80),
             plot_bgcolor='white',
+            hovermode='x unified',
         )
 
         # Streamlit でグラフを表示

--- a/src/components/charts/HourlyReportAnalysisCharts.py
+++ b/src/components/charts/HourlyReportAnalysisCharts.py
@@ -1,7 +1,5 @@
 import streamlit as st
-import matplotlib.pyplot as plt
-from matplotlib.ticker import FuncFormatter
-import numpy as np
+import plotly.graph_objects as go
 
 
 class HourlyReportAnalysisCharts:
@@ -11,20 +9,72 @@ class HourlyReportAnalysisCharts:
         self.time_dic = ['11時','12時','13時','14時','15時','16時','17時','18時','19時','20時','21時','22時','23時']
         self.color_day_dic = {'水':'royalblue','木':'lime','金':'gold','土':'brown','日':'orangered'}
 
-    def currency_formatter(self, 
-                           x, 
-                           _):
-        return f'¥{int(x):,}'
-    
-    def customer_formatter(self, 
-                        x, 
-                        _):
-        return f'{int(x):,}人'
-        
+    def _week_hourly_figure(self, filtered_df, label, height: int = 420):
+        """
+        filtered_df: 行=曜日、列=時間帯 の平均データ
+        """
+        plot_df = filtered_df.T.iloc[0:len(self.time_dic), :]
+        hours = plot_df.index.tolist()
+        fig = go.Figure()
+        for day in plot_df.columns:
+            color = self.color_day_dic.get(str(day), '#888888')
+            y_vals = plot_df[day].tolist()
+            if "売上" in label or "客単価" in label:
+                hovertemplate = f'時間: %{{x}}<br>{day}: ¥%{{y:,.0f}}<extra>{day}</extra>'
+            else:
+                hovertemplate = f'時間: %{{x}}<br>{day}: %{{y:,.1f}}人<extra>{day}</extra>'
+            fig.add_trace(go.Bar(
+                name=str(day),
+                x=hours,
+                y=y_vals,
+                marker_color=color,
+                marker_line_color='black',
+                marker_line_width=1,
+                hovertemplate=hovertemplate,
+            ))
+
+        if "売上" in label or "客単価" in label:
+            yaxis_cfg = dict(
+                title=label,
+                range=[0, 35000],
+                tickformat=',.0f',
+                tickprefix='¥',
+                showgrid=True,
+                gridcolor='#e0e0e0',
+            )
+        else:
+            yaxis_cfg = dict(
+                title=label,
+                range=[0, 30],
+                tickformat='.1f',
+                ticksuffix='人',
+                showgrid=True,
+                gridcolor='#e0e0e0',
+            )
+
+        fig.update_layout(
+            barmode='group',
+            xaxis=dict(title='', tickfont=dict(size=14)),
+            yaxis=yaxis_cfg,
+            legend=dict(
+                orientation='h',
+                yanchor='bottom',
+                y=1.02,
+                xanchor='right',
+                x=1,
+                font=dict(size=11),
+            ),
+            hovermode='x unified',
+            plot_bgcolor='white',
+            margin=dict(l=50, r=20, t=70, b=50),
+            height=height,
+        )
+        return fig
+
     def week_comp_bar(self, df_week, label, selected_days):
         """
         指定された曜日のデータのみを表示する棒グラフを作成
-        
+
         Parameters:
         -----------
         df_week : DataFrame
@@ -34,87 +84,27 @@ class HourlyReportAnalysisCharts:
         selected_days : str
             表示する曜日のリスト。Noneの場合は全ての曜日を表示
         """
-        # 指定された曜日が存在しない場合は全ての曜日を表示
         if selected_days is None or selected_days == "全体":
             filtered_df = df_week
         else:
-            # 指定された曜日のみをフィルタリング
             filtered_df = df_week.loc[[selected_days]]
-        
-        # 表示するデータがない場合
+
         if filtered_df.empty:
             st.warning("選択された曜日のデータがありません。")
             return
-            
-        # 転置して時間データを取り出し、棒グラフを作成
-        fig, ax = plt.subplots(figsize=(15, 5))
-        
-        # グリッドを背景に設定（棒グラフの描画前に配置）
-        ax.grid(True, zorder=0)
-        
-        # フィルタリングされたデータを使用
-        filtered_df.T.iloc[0:len(self.time_dic), :].plot.bar(
-            ax=ax,
-            width=0.8,
-            color=self.color_day_dic,
-            edgecolor='black',
-            linewidth=1,
-            zorder=3  # zorderを高く設定して前面に表示
-        )
 
-        # 軸ラベルの設定
-        if "売上" in label or "客単価" in label:
-            ax.yaxis.set_major_formatter(FuncFormatter(self.currency_formatter))
-            ax.set_ylabel("月の総売上(円)", fontsize=15)
-            ax.set_ylim(0, 35000)  # 売上の上限を¥35,000に設定
-        elif "客数" in label:
-            ax.set_ylabel("月の総客数(人)", fontsize=15)
-            ax.yaxis.set_major_formatter(FuncFormatter(self.customer_formatter))
-            ax.set_ylim(0, 30)  # 客数の上限を30人に設定
-
-        # 軸のフォントサイズ設定
-        ax.tick_params(axis='x', labelsize=15, rotation=0)
-        ax.tick_params(axis='y', labelsize=15)
-
-        # グラフのラベルと凡例
-        ax.set_ylabel(label)
-        ax.legend(fontsize=9, loc='upper right')
-        
-        # グリッドを確実に表示（念のため再設定）
-        plt.grid(True)
-        
-        # グラフをStreamlitで表示
-        st.pyplot(fig)
+        fig = self._week_hourly_figure(filtered_df, label)
+        st.plotly_chart(fig, use_container_width=True)
 
     def compare_two_data(self, df1, df2, label, title1, title2, selected_days1=None, selected_days2=None):
         """
         2つのデータを横に並べて比較するグラフを作成
-        
-        Parameters:
-        -----------
-        df1 : DataFrame
-            比較する1つ目のデータ
-        df2 : DataFrame
-            比較する2つ目のデータ
-        label : str
-            グラフのラベル
-        title1 : str
-            1つ目のデータのタイトル
-        title2 : str
-            2つ目のデータのタイトル
-        selected_days1 : str or list, optional
-            1つ目のデータで表示する曜日。Noneの場合は全ての曜日を表示
-        selected_days2 : str or list, optional
-            2つ目のデータで表示する曜日。Noneの場合は全ての曜日を表示
         """
-        # 2列のレイアウトを作成
         cols = st.columns(2)
-        
-        # 1つ目のデータ
+
         with cols[0]:
             st.write(f"**{title1}**")
             if df1 is not None and not df1.empty:
-                # フィルタリング
                 if selected_days1 is None or selected_days1 == "全体":
                     filtered_df1 = df1
                 else:
@@ -123,47 +113,18 @@ class HourlyReportAnalysisCharts:
                     except KeyError:
                         st.warning(f"選択された曜日 '{selected_days1}' のデータがありません。")
                         return
-                
+
                 if not filtered_df1.empty:
-                    # グラフ作成
-                    fig1, ax1 = plt.subplots(figsize=(8, 5))
-                    ax1.grid(True, zorder=0)
-                    
-                    filtered_df1.T.iloc[0:len(self.time_dic), :].plot.bar(
-                        ax=ax1,
-                        width=0.8,
-                        color=self.color_day_dic,
-                        edgecolor='black',
-                        linewidth=1,
-                        zorder=3
-                    )
-                    
-                    # 軸ラベルの設定
-                    if "売上" in label or "客単価" in label:
-                        ax1.yaxis.set_major_formatter(FuncFormatter(self.currency_formatter))
-                        ax1.set_ylabel("月の総売上(円)", fontsize=10)
-                        ax1.set_ylim(0, 35000)
-                    elif "客数" in label:
-                        ax1.set_ylabel("月の総客数(人)", fontsize=10)
-                        ax1.yaxis.set_major_formatter(FuncFormatter(self.customer_formatter))
-                        ax1.set_ylim(0, 30)
-                    
-                    ax1.tick_params(axis='x', labelsize=10, rotation=0)
-                    ax1.tick_params(axis='y', labelsize=10)
-                    ax1.set_ylabel(label, fontsize=10)
-                    ax1.legend(fontsize=8, loc='upper right')
-                    plt.grid(True)
-                    st.pyplot(fig1)
+                    fig1 = self._week_hourly_figure(filtered_df1, label, height=380)
+                    st.plotly_chart(fig1, use_container_width=True)
                 else:
                     st.warning("表示するデータがありません。")
             else:
                 st.warning("データが存在しません。")
-        
-        # 2つ目のデータ
+
         with cols[1]:
             st.write(f"**{title2}**")
             if df2 is not None and not df2.empty:
-                # フィルタリング
                 if selected_days2 is None or selected_days2 == "全体":
                     filtered_df2 = df2
                 else:
@@ -172,39 +133,11 @@ class HourlyReportAnalysisCharts:
                     except KeyError:
                         st.warning(f"選択された曜日 '{selected_days2}' のデータがありません。")
                         return
-                
+
                 if not filtered_df2.empty:
-                    # グラフ作成
-                    fig2, ax2 = plt.subplots(figsize=(8, 5))
-                    ax2.grid(True, zorder=0)
-                    
-                    filtered_df2.T.iloc[0:len(self.time_dic), :].plot.bar(
-                        ax=ax2,
-                        width=0.8,
-                        color=self.color_day_dic,
-                        edgecolor='black',
-                        linewidth=1,
-                        zorder=3
-                    )
-                    
-                    # 軸ラベルの設定
-                    if "売上" in label or "客単価" in label:
-                        ax2.yaxis.set_major_formatter(FuncFormatter(self.currency_formatter))
-                        ax2.set_ylabel("月の総売上(円)", fontsize=10)
-                        ax2.set_ylim(0, 35000)
-                    elif "客数" in label:
-                        ax2.set_ylabel("月の総客数(人)", fontsize=10)
-                        ax2.yaxis.set_major_formatter(FuncFormatter(self.customer_formatter))
-                        ax2.set_ylim(0, 30)
-                    
-                    ax2.tick_params(axis='x', labelsize=10, rotation=0)
-                    ax2.tick_params(axis='y', labelsize=10)
-                    ax2.set_ylabel(label, fontsize=10)
-                    ax2.legend(fontsize=8, loc='upper right')
-                    plt.grid(True)
-                    st.pyplot(fig2)
+                    fig2 = self._week_hourly_figure(filtered_df2, label, height=380)
+                    st.plotly_chart(fig2, use_container_width=True)
                 else:
                     st.warning("表示するデータがありません。")
             else:
                 st.warning("データが存在しません。")
-


### PR DESCRIPTION
日報分析・月別分析（DailyReportAnalysisCharts）および時間別分析（HourlyReportAnalysisCharts）のグラフを matplotlib から Plotly に置き換えました。

ホバーで値・ラベルを確認しやすくする
凡例クリックで系列の表示／非表示を切り替え可能にする
積み上げ棒・月次棒・時間帯別グループ棒を st.plotly_chart で表示
曜日別比較（weekly_comparison_bar）は同ファイル内のレイアウト整理のみ

<img width="1509" height="818" alt="スクリーンショット 2026-05-07 9 15 27" src="https://github.com/user-attachments/assets/c646635f-1e31-4c55-a96e-d97172522158" />
