### PR TITLE
ラーメン分析・ランチ分析

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -16,7 +16,7 @@ page = st.sidebar.radio(
         "時間別分析",
         "月別分析",
         "曜日別分析",
-        "夜ラーメン",
+        "ラーメン",
         "ランチ分析",
         "アルコール",
         "年間分析"
@@ -48,9 +48,9 @@ elif page == "曜日別分析":
     st.title("みつか坊主 - 曜日別分析")
     analytics.weekly_report_analysis()
 
-elif page == "夜ラーメン":
-    st.title("みつか坊主 - 夜ラーメン")
-    analytics.night_ramen_analysis()
+elif page == "ラーメン":
+    st.title("みつか坊主 - ラーメン")
+    analytics.ramen_analysis()
 
 elif page == "ランチ分析":
     st.title("みつか坊主 - ランチ")

--- a/src/components/charts/LunchAnalysisCharts.py
+++ b/src/components/charts/LunchAnalysisCharts.py
@@ -1,78 +1,127 @@
 import streamlit as st
 import plotly.express as px
 import pandas as pd
+import plotly.graph_objects as go
 
 
 class LunchAnalysisCharts:
     def __init__(self):
         pass
 
+    def pie_lunch_category(
+        self,
+        df_dict: dict,
+        selected_month: str,
+        mode: str = "販売数"
+    ) -> None:
+        TARGET_KEYS = [
+            "カリー", "カリーつけ麺", "海老みそ", "焦がし海老味噌",
+            "ベジ味噌", "白味噌", "温玉カレーラーメン", "油そば",
+            "発酵唐揚げプレート",
+            "発酵御膳",
+            "キッズ"
+        ]
 
-    def bar_ranking_df_by_month(
-            self,
-            df: pd.DataFrame,
-            date: str,
-            fig_title: str
-            ):
-        """
-        指定された年月の各商品の合計販売数をStreamlitで可視化する関数（Plotly版）
-        - df: データフレーム (インデックスが日付)
-        - date: 'YYYY_MM' 形式の文字列
-        """
-        year = int(date[:4])
-        month = int(date.split('_')[1])        # データを販売数の降順に並べ替え
-        df_sorted = df.sort_values(ascending=False)
+        year  = int(selected_month[:4])
+        month = int(selected_month.split('_')[1])
 
-        # 商品の順位に基づいて色を設定
-        color_map = {
-            0: '#FFD700',   # 1位: Gold
-            1: '#C0C0C0',   # 2位: Silver
-            2: '#CD7F32',   # 3位: Bronze
-        }
+        def _sum_key(key: str) -> float:
+            # 部分一致をやめ、直接指定に変更
+            if key not in df_dict:
+                return 0.0
+            
+            df = df_dict[key].copy()
+            if not pd.api.types.is_datetime64_any_dtype(df.index):
+                df.index = pd.to_datetime(df.index)
+            
+            # 指定年月のデータを抽出
+            target_df = df[(df.index.year == year) & (df.index.month == month)]
+            # 全カラムの合計を合算して返す
+            return float(pd.to_numeric(target_df.values.flatten(), errors='coerce').sum())
 
-        # その他の商品は青色
-        colors = [color_map.get(i, 'blue') for i in range(len(df_sorted))]
+        totals_dict = {key: _sum_key(key) for key in TARGET_KEYS}
+        totals = pd.Series(totals_dict)
+        totals = totals[totals > 0].sort_values(ascending=False)
 
-        # plotlyでグラフ作成
-        fig = px.bar(
-            df_sorted,
-            x=df_sorted.index,
-            y=df_sorted.values,
-            labels={"x": "商品", "y": "販売数"},
-            title=f"{year}年{month}月 の {fig_title}",
-            color=colors,  # 色を設定
-            color_discrete_map='identity'  # カスタム色を適用
-        )
+        if totals.empty:
+            st.warning(f"{year}年{month}月のデータがありません。")
+            return
 
+        fig = go.Figure(go.Pie(
+            labels=totals.index.tolist(),
+            values=totals.values.tolist(),
+            textinfo="label+percent",
+            insidetextorientation='horizontal', 
+            hole=0.3,
+            sort=True, # グラフを降順にする
+            direction='clockwise',
+            rotation=0,
+        ))
         fig.update_layout(
-            xaxis=dict(title=''),
-            xaxis_tickangle=-45,
-            margin=dict(l=20, r=20, t=40, b=80)
+            title_text=f"{year}年{month}月 昼カテゴリ別{mode}割合",
+            margin=dict(l=50, r=50, t=80, b=50),
+            height=500,
+            legend=dict(
+            orientation="h",
+            yanchor="top",
+            y=-0.2, 
+            xanchor="center",
+            x=0.5
         )
-
+        )
         st.plotly_chart(fig, use_container_width=True)
 
-    def line_trend_df(
-            self,
-            df: pd.DataFrame,
-            fig_title: str
-            ):
-        """
-        指定されたデータフレームの各商品の販売数の推移をStreamlitで可視化する関数（Plotly版）
-        - df: データフレーム (インデックスが日付)
-        """
-        # plotlyでグラフ作成
-        fig = px.line(
-            df,
-            x=df.index,
-            y=df.columns,
-            labels={"x": "日付", "value": "販売数", "variable": "商品"},
-            title=f"{fig_title} の販売数推移"
-        )
+    def pie_set_menu(
+        self,
+        df_dict: dict,
+        selected_month: str,
+        mode: str = "販売数"
+    ) -> None:
+        SET_KEYS = ["セット", "ラーメンセット"]
+        year = int(selected_month[:4])
+        month = int(selected_month.split('_')[1])
+
+        def _sum_by_item(key: str) -> pd.Series:
+            if key not in df_dict: return pd.Series(dtype=float)
+            df = df_dict[key].copy()
+            if not pd.api.types.is_datetime64_any_dtype(df.index):
+                df.index = pd.to_datetime(df.index)
+            df = df[(df.index.year == year) & (df.index.month == month)]
+            return df.apply(pd.to_numeric, errors='coerce').sum()
+
+        combined = pd.concat([_sum_by_item(k) for k in SET_KEYS]).fillna(0)
+        combined = combined[combined > 0]
+
+        if combined.empty:
+            st.warning("該当月のセットデータがありません")
+            return
+
+        combined = combined.sort_index(ascending=True)
+
+        fig = go.Figure(go.Pie(
+            labels=combined.index.tolist(),
+            values=combined.values.tolist(),
+            textinfo="label+percent",
+            insidetextorientation='horizontal',
+            hole=0.3,
+            sort=True, 
+            direction='clockwise',
+            rotation=0,
+            marker_colors=px.colors.qualitative.Set2,
+        ))
 
         fig.update_layout(
-            xaxis=dict(title=''),
-            margin=dict(l=20, r=20, t=40, b=80)
+            title_text=f"{year}年{month}月 セットメニュー{mode}内訳",
+            title_font_size=16,
+            margin=dict(l=50, r=50, t=80, b=50),
+            height=420,
+            showlegend=True,
+            legend=dict(
+            orientation="h",
+            yanchor="top",
+            y=-0.2, 
+            xanchor="center",
+            x=0.5
         )
-
+        )
         st.plotly_chart(fig, use_container_width=True)

--- a/src/components/charts/RamenAnalysisCharts.py
+++ b/src/components/charts/RamenAnalysisCharts.py
@@ -1,0 +1,278 @@
+import streamlit as st
+import plotly.express as px
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+import pandas as pd
+
+
+class RamenAnalysisCharts:
+    """昼・夜・深夜のラーメン分析グラフクラス"""
+
+    # ──────────────────────────────────────────
+    # メニュー共通カラーマップ
+    # ──────────────────────────────────────────
+    MENU_COLORS = {
+        # 味噌系
+        "白味噌":           "#C8A882",   # 濃い肌色
+        "赤味噌":           "#8B1A1A",   # 濃い赤
+        "辛味噌":           "#CC2200",   # 辛そうな赤
+        "焦がし味噌北海道": "#FFD700",   # 明るい黄色
+        "ベジ味噌":         "#6B8E6B",   # 草色（野菜）
+        "あさりと味噌":     "#7BA7BC",   # 青みがかった色（あさり）
+        # つけ麺系
+        "つけ麺8号":        "#4682B4",   # スチールブルー
+        "つけ麺6号":        "#C04000",   # 辛そうな赤
+        "カリーつけ麺":     "#E0B870",   # やや黄みがかった肌色
+        # カリー・海老系
+        "カリー":           "#C8860A",   # カレー色
+        "海老味噌カリー":   "#B06020",   # 海老味噌カリー
+        "担々麺":           "#C04000",   # 担々麺（橙赤）
+        "TOYONO":           "#9B7BB8",   # 紫系（独自色）
+        "イカスミ":         "#2C2C2C",   # 黒
+        "油そば":           "#5C3A1E",   # 醤油色（茶）
+        "和え玉":           "#32CD32",   # ライムグリーン
+        # 昼ランチ系
+        "海老みそ":         "#D4785A",   # 海老みそ（淡い海老色）
+        "焦がし海老味噌":   "#A0522D",   # 焦がし感（茶系）
+        "温玉カレーラーメン":"#D4A820",  # カレー黄
+        "シビ辛丼":         "#B03000",   # 辛そうな橙赤
+    }
+    # カラーマップにないメニューへのフォールバック用パレット
+    _FALLBACK_COLORS = px.colors.qualitative.Pastel
+
+    TIME_COLORS = {
+        "昼":   px.colors.qualitative.Pastel,
+        "夜":   px.colors.qualitative.Set2,
+        "深夜": px.colors.qualitative.Dark2,
+    }
+    WEEKDAY_ORDER = ["水", "木", "金", "土", "日"]
+    WEEKDAY_MAP = {0: "月", 1: "火", 2: "水", 3: "木", 4: "金", 5: "土", 6: "日"}
+
+
+    # ──────────────────────────────────────────
+    # ヘルパー：メニュー名リストから色リストを生成
+    # ──────────────────────────────────────────
+    def _get_menu_color_list(self, labels: list[str]) -> list[str]:
+        """
+        labels の順番に対応する色リストを返す。
+        MENU_COLORS に定義がないメニューはフォールバックパレットから順番に割り当てる。
+        """
+        colors = []
+        fallback_idx = 0
+        for label in labels:
+            if label in self.MENU_COLORS:
+                colors.append(self.MENU_COLORS[label])
+            else:
+                colors.append(self._FALLBACK_COLORS[fallback_idx % len(self._FALLBACK_COLORS)])
+                fallback_idx += 1
+        return colors
+
+    # ──────────────────────────────────────────
+    # 内部ヘルパー：月範囲フィルタ
+    # ──────────────────────────────────────────
+    def _filter_by_month_range(
+        self,
+        df: pd.DataFrame,
+        month_start: str,   # 'YYYY_M'
+        month_end:   str,   # 'YYYY_M'
+    ) -> pd.DataFrame:
+        """
+        DataFrame のインデックス（日付）を month_start 〜 month_end の範囲で絞り込む。
+        """
+        if df.empty:
+            return df
+
+        # 範囲内のDataFrameを返すために、インデックスが日付でない場合は変換してから比較する
+        work_df = df.copy()
+        if not pd.api.types.is_datetime64_any_dtype(work_df.index):
+            work_df.index = pd.to_datetime(work_df.index)
+
+        # 'YYYY_M' → period('M') に変換して比較
+        start_period = pd.Period(month_start.replace("_", "-"), freq="M")
+        end_period   = pd.Period(month_end.replace("_", "-"),   freq="M")
+        index_periods = work_df.index.to_period("M")
+
+        # 指定月の行だけを抽出
+        mask = (index_periods >= start_period) & (index_periods <= end_period)
+        return work_df.loc[mask]
+    
+    # 文字列 'YYYY_M' を 'YYYY年M月' 形式に変換して、範囲表示も考慮したラベルを返す関数
+    def _month_range_label(self, month_start: str, month_end: str) -> str:
+        """'2024_4', '2024_6' → '2024年4月〜2024年6月' のような表示文字列を返す"""
+        def fmt(m: str) -> str:
+            y, mo = m.split("_")
+            return f"{y}年{mo}月"
+        return fmt(month_start) if month_start == month_end else f"{fmt(month_start)}〜{fmt(month_end)}"
+
+    # ──────────────────────────────────────────
+    # 1. 円グラフ：昼・夜・深夜ごとの提供割合
+    # ──────────────────────────────────────────
+    def pie_ramen_ratio_by_time(
+        self,
+        df_lunch:    pd.DataFrame,
+        df_diner:    pd.DataFrame,
+        df_midnight: pd.DataFrame,
+        time_filter: str = "全体",
+        month_start: str | None = None,
+        month_end:   str | None = None,
+        mode:  str = "販売数",
+    ) -> None:
+        datasets = {"昼": df_lunch, "夜": df_diner, "深夜": df_midnight}
+        targets = datasets if time_filter == "全体" else {time_filter: datasets[time_filter]}
+
+        # 月範囲フィルタ
+        if month_start and month_end:
+            targets = {
+                label: self._filter_by_month_range(df, month_start, month_end)
+                for label, df in targets.items()
+            }
+
+        # ── 全体の場合は3つを結合して1つのDataFrameに ──
+        if time_filter == "全体":
+            combined_df = pd.concat(targets.values())
+            # 同じメニュー列が昼・夜・深夜で重複しているので列ごとに合算
+            combined_df = combined_df.groupby(combined_df.index).sum()
+            targets = {"全体": combined_df}
+
+        n = len(targets)
+        fig = make_subplots(
+            rows=1, cols=n,
+            specs=[[{"type": "pie"}] * n],
+            vertical_spacing=0.1,
+        )
+
+        unit = "円" if mode == "売上" else "杯"
+        for col_idx, (label, df) in enumerate(targets.items(), start=1):
+            totals = df.sum(numeric_only=True)
+            totals = totals[totals > 0]
+            # 降順ソート
+            totals = totals.sort_values(ascending=False)
+
+            # 全体に占める割合が3%未満のスライスはラベルを非表示にしてlegendに逃がす
+            total_sum = totals.sum()
+            threshold = 0.03
+
+            visible_labels = [
+                lbl if (val / total_sum) >= threshold else ""
+                for lbl, val in zip(totals.index.tolist(), totals.values.tolist())
+            ]
+
+            fig.add_trace(
+                go.Pie(
+                    labels=totals.index.tolist(),
+                    values=totals.values.tolist(),
+                    name=label,
+                    text=visible_labels,   
+                    textinfo="text+percent",
+                    hovertemplate=f"%{{label}}<br>%{{value:,.0f}}{unit}<br>%{{percent}}<extra></extra>",
+                    hole=0.3,
+                    rotation=0, # 0度スタート
+                    direction="clockwise",
+                    insidetextorientation="horizontal", # テキストを水平に
+                    # メニュー共通カラー
+                    marker_colors=self._get_menu_color_list(totals.index.tolist()),
+                ),
+                row=1, col=col_idx,
+            )
+            
+        range_str = self._month_range_label(month_start, month_end) if month_start and month_end else ""
+        fig.update_layout(
+            title_text=f"【{time_filter}】{range_str} ラーメン{mode}割合",
+            margin=dict(l=20, r=20, t=130, b=80),
+            height=550,
+            legend=dict(orientation="h", yanchor="top", y=-0.2, xanchor="center", x=0.5) # 凡例を下へ
+        )
+        st.plotly_chart(fig, use_container_width=True)
+
+    # ──────────────────────────────────────────
+    # 2. 棒グラフ：曜日ごとの各ラーメン提供杯数
+    # ──────────────────────────────────────────
+    def bar_ramen_by_weekday(
+        self,
+        df_lunch:    pd.DataFrame,
+        df_diner:    pd.DataFrame,
+        df_midnight: pd.DataFrame,
+        time_filter: str = "全体",
+        month_start: str | None = None,
+        month_end:   str | None = None,
+        mode: str = "販売数"
+    ) -> None:
+        datasets = {"昼": df_lunch, "夜": df_diner, "深夜": df_midnight}
+        targets  = datasets if time_filter == "全体" else {time_filter: datasets[time_filter]}
+
+        # 月範囲フィルタ
+        if month_start and month_end:
+            targets = {
+                label: self._filter_by_month_range(df, month_start, month_end)
+                for label, df in targets.items()
+            }
+
+         # ── 全体の場合は3つを結合して1つのDataFrameに ──
+        if time_filter == "全体":
+            combined_df = pd.concat(targets.values())
+            combined_df = combined_df.groupby(combined_df.index).sum()
+            targets = {"全体": combined_df}
+
+        range_str = self._month_range_label(month_start, month_end) if month_start and month_end else ""
+
+        if len(targets) == 1:
+            label, df = next(iter(targets.items()))
+            self._render_weekday_bar(df, label, range_str, mode)
+        else:
+            tabs = st.tabs(list(targets.keys()))
+            for tab, (label, df) in zip(tabs, targets.items()):
+                with tab:
+                    self._render_weekday_bar(df, label, range_str, mode)
+
+    # ──────────────────────────────────────────
+    # 内部ヘルパー：棒グラフ描画
+    # ──────────────────────────────────────────
+    def _render_weekday_bar(self, df: pd.DataFrame, label: str, range_str: str , mode: str = "販売数") -> None:
+        if df.empty:
+            st.warning(f"{label}のデータがありません")
+            return
+
+        work_df = df.copy()
+        if not pd.api.types.is_datetime64_any_dtype(work_df.index):
+            work_df.index = pd.to_datetime(work_df.index)
+
+        work_df["曜日"] = work_df.index.dayofweek.map(self.WEEKDAY_MAP)
+        numeric_cols = work_df.select_dtypes(include="number").columns.tolist()
+        weekday_df = (
+            work_df.groupby("曜日")[numeric_cols]
+            .sum()
+            .reindex(self.WEEKDAY_ORDER)
+            .fillna(0)
+        )
+
+        color_map = {col: self.MENU_COLORS.get(col, self._FALLBACK_COLORS[i % len(self._FALLBACK_COLORS)])
+                     for i, col in enumerate(numeric_cols)}
+
+        unit = "円" if mode == "売上" else "杯"
+        y_label = f"{mode}合計 ({unit})" # 軸のタイトル用
+
+        fig = px.bar(
+            weekday_df.reset_index(),
+            x="曜日",
+            y=numeric_cols,
+            barmode="group",
+            labels={"value": mode, "variable": "メニュー", "曜日": "曜日"},
+            title=f"【{label}】{range_str} 曜日別ラーメン{mode}",
+            color_discrete_map = color_map
+        )
+        fig.update_layout(
+            xaxis=dict(title="曜日", categoryorder="array", categoryarray=self.WEEKDAY_ORDER),
+            yaxis=dict(
+                title=y_label,
+                tickformat=",d" if mode == "売上" else None # 売上の時だけカンマ区切り
+            ),
+            legend=dict(title="メニュー", orientation="v", x=1.02, y=0.5),
+            margin=dict(l=20, r=20, t=80, b=40),
+            height=450,
+        )
+
+        fig.update_traces(
+            hovertemplate=f"曜日: %{{x}}<br>メニュー: %{{fullData.name}}<br>{mode}: %{{y:,.0f}}{unit}<extra></extra>"
+        )
+
+        st.plotly_chart(fig, use_container_width=True)

--- a/src/components/pages/analytics.py
+++ b/src/components/pages/analytics.py
@@ -11,6 +11,9 @@ from src.components.utils.DailyReportAnalysisUtils import DailyReportAnalysisUti
 from src.components.utils.HourlyReportAnalysisUtils import HourlyReportAnalysisUtils
 from src.components.utils.LunchAnalysisUtils import LunchAnalysisUtils
 from src.components.charts.LunchAnalysisCharts import LunchAnalysisCharts
+from src.components.utils.MidnightAnalysisUtils import MidnightAnalysisUtils
+from src.components.utils.DinerAnalysisUtils import DinerAnalysisUtils
+from src.components.charts.RamenAnalysisCharts import RamenAnalysisCharts
 from src.components.utils.AlcoholAnalysisUtils import AlcoholAnalysisUtils
 from src.components.charts.AlcoholAnalysisCharts import AlcoholAnalysisCharts
 from src.components.utils.GetByProductDf import GetByProductDf
@@ -47,6 +50,24 @@ def get_lunch_analysis_charts() -> LunchAnalysisCharts:
     return LunchAnalysisCharts()
 
 @st.cache_resource
+def get_midnight_analysis_utils() -> MidnightAnalysisUtils:
+    return MidnightAnalysisUtils()
+
+@st.cache_resource
+def get_diner_analysis_utils() -> DinerAnalysisUtils:
+    return DinerAnalysisUtils()
+
+@st.cache_resource
+def get_ramen_analysis_charts() -> RamenAnalysisCharts:
+    return RamenAnalysisCharts()
+
+"""
+@st.cache_resource
+def get_midnight_analysis_charts() -> MidnightAnalysisCharts:
+    return MidnightAnalysisCharts()
+"""
+
+@st.cache_resource
 def get_alcohol_analysis_utils() -> AlcoholAnalysisUtils:
     return AlcoholAnalysisUtils()
 
@@ -73,6 +94,11 @@ hourlyReportAnalysisUtils = get_hourly_report_analysis_utils()
 hourlyReportAnalysisCharts = get_hourly_report_analysis_charts()
 lunchAnalysisUtils = get_lunch_analysis_utils()
 lunchAnalysisCharts = get_lunch_analysis_charts()
+midnightAnalysisUtils = get_midnight_analysis_utils()
+dinerAnalysisUtils = get_diner_analysis_utils()
+ramenAnalysisCharts = get_ramen_analysis_charts()
+
+#MidnightAnalysisCharts = get_midnight_analysis_charts()
 alcoholAnalysisUtils = get_alcohol_analysis_utils()
 alcoholAnalysisCharts = get_alcohol_analysis_charts()
 getByProductDf = get_by_product_df()
@@ -115,7 +141,7 @@ def hourly_report_analysis():
     時間別分析のグラフ
     '''
     # バーでファイルを選択
-    month_list = HourlyReportAnalysisUtils.get_month_list()
+    month_list = hourlyReportAnalysisUtils.get_month_list()
     selected_month = st.selectbox("表示したい年月を選択", month_list[::-1])
     try:
         option_daily = st.selectbox("↓↓↓売上か客数を選択↓↓↓", ["客数","売上"])
@@ -127,22 +153,21 @@ def hourly_report_analysis():
         
         # グラフ表示
         st.write(f'{selected_month}の時間別の{option_daily}データ({selected_days})')
-        if option_daily == "売上":
-            file_path = hourlyReportAnalysisUtils.get_sales_file_path_by_date(selected_month)
-            data = pd.read_csv(file_path,index_col=0)
-            data = hourlyReportAnalysisUtils.convert_hourly_report_data(data)
-            data = hourlyReportAnalysisUtils.get_week_groupby_mean(data)
-            
-            # 曜日を渡すように修正
-            hourlyReportAnalysisCharts.week_comp_bar(data, '売上額 (¥)', selected_days)
-        elif option_daily == "客数":
-            file_path = hourlyReportAnalysisUtils.get_cus_file_path_by_date(selected_month)
-            data = pd.read_csv(file_path,index_col=0)
-            data = hourlyReportAnalysisUtils.convert_hourly_report_data(data)
-            data = hourlyReportAnalysisUtils.get_week_groupby_mean(data)
 
-            # 曜日を渡すように修正
-            hourlyReportAnalysisCharts.week_comp_bar(data, '客数 (人)', selected_days)
+        # メインデータ取得・表示
+        kind  = "売上" if option_daily == "売上" else "客数"
+        label = '売上額 (¥)' if option_daily == "売上" else '客数 (人)'
+
+        #売上or客数のデータを取得し、pd.DataFrameに変換
+        data = hourlyReportAnalysisUtils.get_df_from_dic(selected_month, kind=kind)
+        if data.empty:
+            st.warning("該当月のデータがありません")
+            return 
+
+        data = hourlyReportAnalysisUtils.get_week_groupby_mean(data)
+        # 曜日を渡すように修正
+        hourlyReportAnalysisCharts.week_comp_bar(data, label, selected_days)
+
             
         # 比較分析セクション
         st.markdown("---")
@@ -150,6 +175,8 @@ def hourly_report_analysis():
         
         # 比較する対象（売上/客数）を選択
         compare_option = st.selectbox("比較する対象", ["売上", "客数"], key="compare_option")
+        compare_label  = '売上額 (¥)' if compare_option == "売上" else '客数 (人)'
+        compare_kind   = "売上" if compare_option == "売上" else "客数"
         
         # 2つのデータを比較するためのUI
         col1, col2 = st.columns(2)
@@ -164,44 +191,30 @@ def hourly_report_analysis():
             second_month = st.selectbox("月を選択", month_list[::-1], key="second_month")
             second_day = st.selectbox("曜日を選択", day_options, key="second_day_month")
         
-        # データの取得 - 1つ目
-        if compare_option == "売上":
-            first_file_path = hourlyReportAnalysisUtils.get_sales_file_path_by_date(first_month)
-            label = '売上額 (¥)'
-        else:  # 客数
-            first_file_path = hourlyReportAnalysisUtils.get_cus_file_path_by_date(first_month)
-            label = '客数 (人)'
+        # 比較データ取得、kindで売上か客数かを選択し、pd.DataFrameに変換
+        first_data  = hourlyReportAnalysisUtils.get_df_from_dic(first_month,  kind=compare_kind)
+        second_data = hourlyReportAnalysisUtils.get_df_from_dic(second_month, kind=compare_kind)
+
+        if first_data.empty:
+            st.warning(f"{first_month}のデータが見つかりません。")
+            return
+        if second_data.empty:
+            st.warning(f"{second_month}のデータが見つかりません。")
+            return
         
-        # データの取得 - 2つ目
-        if compare_option == "売上":
-            second_file_path = hourlyReportAnalysisUtils.get_sales_file_path_by_date(second_month)
-        else:  # 客数
-            second_file_path = hourlyReportAnalysisUtils.get_cus_file_path_by_date(second_month)
-        
-        # データの処理と表示
-        if first_file_path and second_file_path:
-            first_data = pd.read_csv(first_file_path, index_col=0)
-            first_data = hourlyReportAnalysisUtils.convert_hourly_report_data(first_data)
-            first_data = hourlyReportAnalysisUtils.get_week_groupby_mean(first_data)
+        # 曜日を渡すように修正
+        first_data  = hourlyReportAnalysisUtils.get_week_groupby_mean(first_data)
+        second_data = hourlyReportAnalysisUtils.get_week_groupby_mean(second_data)
             
-            second_data = pd.read_csv(second_file_path, index_col=0)
-            second_data = hourlyReportAnalysisUtils.convert_hourly_report_data(second_data)
-            second_data = hourlyReportAnalysisUtils.get_week_groupby_mean(second_data)
-            
-            # 比較グラフを表示
-            hourlyReportAnalysisCharts.compare_two_data(
-                first_data, second_data, 
-                label, 
-                f"{first_month} ({first_day})", 
-                f"{second_month} ({second_day})",
-                first_day if first_day != "全体" else None,
-                second_day if second_day != "全体" else None
-            )
-        else:
-            if not first_file_path:
-                st.warning(f"{first_month}のデータが見つかりません。")
-            if not second_file_path:
-                st.warning(f"{second_month}のデータが見つかりません。")
+        # 比較グラフの表示
+        hourlyReportAnalysisCharts.compare_two_data(
+            first_data, second_data,
+            compare_label,
+            f"{first_month} ({first_day})",
+            f"{second_month} ({second_day})",
+            first_day  if first_day  != "全体" else None,
+            second_day if second_day != "全体" else None
+        )
             
     except Exception as e:
         st.error(f"エラーが発生しました: {e}")
@@ -338,32 +351,120 @@ def weekly_report_analysis():
             st.metric(day, formatted_value, change)
 
 
-def night_ramen_analysis():
+def ramen_analysis():
     '''
-    夜ラーメン分析のグラフ
+    ラーメン分析のグラフ
     '''
-    st.title("開発中...🐭")
+    try:
+        # ラーメンの種類を選択
+        option_time = st.selectbox("時間帯", ["昼","夜","深夜","全体"])
+
+        # 表示モード（販売数 or 売上）の選択
+        col_mode, col_blank = st.columns([1, 1])
+        with col_mode:
+            analysis_mode = st.radio("表示モード", ["販売数", "売上"], horizontal=True)
+
+        # 月リストを新しい順で取得
+        month_list = lunchAnalysisUtils.get_month_list()[::-1]
+
+        col1, col2 = st.columns(2)
+        with col1:
+            option_month_start = st.selectbox("開始月", month_list, index=0)
+        with col2:
+            # 終了月の初期値を開始月と同じにする
+            start_idx = month_list.index(option_month_start)
+            option_month_end = st.selectbox("終了月", month_list, index=start_idx)
+
+        # 開始 > 終了の逆転を防ぐ（古い順のインデックスで比較）
+        month_list_asc = lunchAnalysisUtils.get_month_list()  # 昇順
+        idx_start = month_list_asc.index(option_month_start)
+        idx_end   = month_list_asc.index(option_month_end)
+        if idx_start > idx_end:
+            st.warning("⚠️ 開始月が終了月より新しいです。開始月と終了月を入れ替えて表示します。")
+            option_month_start, option_month_end = option_month_end, option_month_start
+
+
+        # モードに応じてベースとなるDataFrameを切り替え
+        if analysis_mode == "売上":
+            df_base = getByProductDf.df_all_sale
+        else:
+            df_base = getByProductDf.df_all_num
+
+        lunch_json = read_json_file(filepath='data/json/lunch.json')
+        midnight_json = read_json_file(filepath='data/json/深夜限定.json')
+        diner_json = read_json_file(filepath='data/json/ディナー.json')
+
+        dict_lunch = getByProductDf.json_to_df_dict(df_all=df_base, json_dict=lunch_json)
+        dict_midnight = getByProductDf.json_to_df_dict(df_all=df_base, json_dict=midnight_json)
+        dict_diner = getByProductDf.json_to_df_dict(df_all=df_base, json_dict=diner_json)
+
+        df_lunch = lunchAnalysisUtils.prepare_ramen_df_num(dict_lunch)
+        df_midnight = midnightAnalysisUtils.prepare_midnight_df_num(dict_midnight)
+        df_diner = dinerAnalysisUtils.prepare_diner_df_num(dict_diner)
+
+        charts = RamenAnalysisCharts()
+
+        st.subheader(f"🥣 ラーメン{analysis_mode}割合（円グラフ）")
+        charts.pie_ramen_ratio_by_time(
+            df_lunch, df_diner, df_midnight,
+            time_filter=option_time,
+            month_start=option_month_start,
+            month_end=option_month_end,
+            mode=analysis_mode
+        )
+
+        st.subheader(f"📊 曜日別ラーメン{analysis_mode}（棒グラフ）")
+        charts.bar_ramen_by_weekday(
+            df_lunch, df_diner, df_midnight,
+            time_filter=option_time,
+            month_start=option_month_start,
+            month_end=option_month_end,
+            mode=analysis_mode
+        )
+
+
+    except Exception as e:
+        st.error(f"エラーが発生しました: {e}")
 
 def lunch_ramen_analysis():
-    '''
-    ランチラーメン分析のグラフ
-    '''
-    st.title("開発中...🐭")
     month_list = lunchAnalysisUtils.get_month_list()
-    selected_month = st.selectbox("どの年月を表示しますか？", month_list[::-1])
-    df_val_num = getByProductDf.df_all_val
-    df_val_sale = getByProductDf.df_all_sale
+    
+    # ユーザー選択エリア
+    col1, col2 = st.columns(2)
+    with col1:
+        selected_month = st.selectbox("どの年月を表示しますか？", month_list[::-1])
+    with col2:
+        # 販売数か売上かを選択
+        mode = st.radio("集計モード", ["販売数", "売上"], horizontal=True)
 
+    # --- データ準備 ---
+    # 数量データ
+    df_val_num = getByProductDf.df_all_num
     lunch_json = read_json_file(filepath='data/json/lunch.json')
-    df_val_num_dict = getByProductDf.json_to_df_dict(df_all=df_val_num
-                                                 ,json_dict=lunch_json)
-    df_val_sale_dict = getByProductDf.json_to_df_dict(df_all=df_val_sale
-                                                 ,json_dict=lunch_json)
-    df_ramen = lunchAnalysisUtils.prepare_ramen_df_num(df_val_num_dict)
+    df_val_num_dict = getByProductDf.json_to_df_dict(
+        df_all=df_val_num, json_dict=lunch_json
+    )
 
-    result_ramen = lunchAnalysisUtils.summarize_ramen_sales(df_ramen, selected_month)
-    lunchAnalysisCharts.bar_ranking_df_by_month(result_ramen, selected_month, "ラーメンの合計販売数")
-    lunchAnalysisCharts.line_trend_df(df_ramen, "ラーメンの販売数推移")
+    # 売上データ
+    df_sale_num = getByProductDf.df_all_sale
+    df_val_sale_dict = getByProductDf.json_to_df_dict(
+        df_all=df_sale_num, json_dict=lunch_json
+    )
+
+    # モードによって渡す辞書を切り替える
+    target_dict = df_val_sale_dict if mode == "売上" else df_val_num_dict
+    
+    # 単位のラベル（任意でグラフに渡すと親切です）
+    unit = "円" if mode == "売上" else "個/杯"
+
+    # --- グラフ表示 ---
+    st.subheader(f"🥣 昼カテゴリ別{mode}割合")
+    # クラス側のメソッドにmodeやunitを渡せるようにしておくと汎用性が高まります
+    lunchAnalysisCharts.pie_lunch_category(target_dict, selected_month, mode)
+
+    st.subheader(f"🍱 セットメニュー{mode}内訳")
+    lunchAnalysisCharts.pie_set_menu(target_dict, selected_month, mode)
+
 
 def alchohol_analysis():
     '''
@@ -377,7 +478,7 @@ def alchohol_analysis():
         st.write(f'月単位の{option_alcohol}データ')
 
 
-        df_val_num = getByProductDf.df_all_val
+        df_val_num = getByProductDf.df_all_num
         df_val_sale = getByProductDf.df_all_sale
 
         alcohol_json = read_json_file(filepath='data/json/alcohol.json')

--- a/src/components/pages/analytics.py
+++ b/src/components/pages/analytics.py
@@ -87,6 +87,22 @@ def get_yearly_report_analysis_utils() -> YearlyReportAnalysisUtils:
 def get_yearly_report_analysis_charts() -> YearlyReportAnalysisCharts:
     return YearlyReportAnalysisCharts()
 
+@st.cache_resource
+def get_lunch_json():
+    return read_json_file(filepath='data/json/lunch.json')
+
+@st.cache_resource
+def get_midnight_json():
+    return read_json_file(filepath='data/json/深夜限定.json')
+
+@st.cache_resource
+def get_diner_json():
+    return read_json_file(filepath='data/json/ディナー.json')
+
+@st.cache_resource
+def get_alcohol_json():
+    return read_json_file(filepath='data/json/alcohol.json')
+
 # ここでキャッシュされたインスタンスをグローバル変数に格納（実際の関数内でも取得可能）
 dailyReportAnalysisUtils = get_daily_report_analysis_utils()
 dailyReportAnalysisCharts = get_daily_report_analysis_charts()
@@ -97,13 +113,17 @@ lunchAnalysisCharts = get_lunch_analysis_charts()
 midnightAnalysisUtils = get_midnight_analysis_utils()
 dinerAnalysisUtils = get_diner_analysis_utils()
 ramenAnalysisCharts = get_ramen_analysis_charts()
-
-#MidnightAnalysisCharts = get_midnight_analysis_charts()
 alcoholAnalysisUtils = get_alcohol_analysis_utils()
 alcoholAnalysisCharts = get_alcohol_analysis_charts()
 getByProductDf = get_by_product_df()
 yearlyReportAnalysisUtils = get_yearly_report_analysis_utils()
 yearlyReportAnalysisCharts = get_yearly_report_analysis_charts()
+
+# キャッシュ済みのJSONデータをグローバル変数に格納
+lunch_json    = get_lunch_json()
+midnight_json = get_midnight_json()
+diner_json    = get_diner_json()
+alcohol_json  = get_alcohol_json()
 
 
 def show():
@@ -222,9 +242,6 @@ def hourly_report_analysis():
 
     
 def monthly_report_analysis():
-    # インスタンス化
-    # dailyReportAnalysisUtils = DailyReportAnalysisUtils()
-    # dailyReportAnalysisCharts = DailyReportAnalysisCharts()
     '''
     月毎のグラフ表示
     '''
@@ -360,7 +377,7 @@ def ramen_analysis():
         option_time = st.selectbox("時間帯", ["昼","夜","深夜","全体"])
 
         # 表示モード（販売数 or 売上）の選択
-        col_mode, col_blank = st.columns([1, 1])
+        col_mode, _ = st.columns([1, 1])
         with col_mode:
             analysis_mode = st.radio("表示モード", ["販売数", "売上"], horizontal=True)
 
@@ -390,10 +407,6 @@ def ramen_analysis():
         else:
             df_base = getByProductDf.df_all_num
 
-        lunch_json = read_json_file(filepath='data/json/lunch.json')
-        midnight_json = read_json_file(filepath='data/json/深夜限定.json')
-        diner_json = read_json_file(filepath='data/json/ディナー.json')
-
         dict_lunch = getByProductDf.json_to_df_dict(df_all=df_base, json_dict=lunch_json)
         dict_midnight = getByProductDf.json_to_df_dict(df_all=df_base, json_dict=midnight_json)
         dict_diner = getByProductDf.json_to_df_dict(df_all=df_base, json_dict=diner_json)
@@ -402,10 +415,8 @@ def ramen_analysis():
         df_midnight = midnightAnalysisUtils.prepare_midnight_df_num(dict_midnight)
         df_diner = dinerAnalysisUtils.prepare_diner_df_num(dict_diner)
 
-        charts = RamenAnalysisCharts()
-
         st.subheader(f"🥣 ラーメン{analysis_mode}割合（円グラフ）")
-        charts.pie_ramen_ratio_by_time(
+        ramenAnalysisCharts.pie_ramen_ratio_by_time(
             df_lunch, df_diner, df_midnight,
             time_filter=option_time,
             month_start=option_month_start,
@@ -414,7 +425,7 @@ def ramen_analysis():
         )
 
         st.subheader(f"📊 曜日別ラーメン{analysis_mode}（棒グラフ）")
-        charts.bar_ramen_by_weekday(
+        ramenAnalysisCharts.bar_ramen_by_weekday(
             df_lunch, df_diner, df_midnight,
             time_filter=option_time,
             month_start=option_month_start,
@@ -440,7 +451,6 @@ def lunch_ramen_analysis():
     # --- データ準備 ---
     # 数量データ
     df_val_num = getByProductDf.df_all_num
-    lunch_json = read_json_file(filepath='data/json/lunch.json')
     df_val_num_dict = getByProductDf.json_to_df_dict(
         df_all=df_val_num, json_dict=lunch_json
     )
@@ -477,52 +487,19 @@ def alchohol_analysis():
         # グラフ表示
         st.write(f'月単位の{option_alcohol}データ')
 
-
-        df_val_num = getByProductDf.df_all_num
-        df_val_sale = getByProductDf.df_all_sale
-
-        alcohol_json = read_json_file(filepath='data/json/alcohol.json')
-        df_val_num_dict = getByProductDf.json_to_df_dict(df_all=df_val_num
-                                                    ,json_dict=alcohol_json)
-        df_val_sale_dict = getByProductDf.json_to_df_dict(df_all=df_val_sale
-                                                    ,json_dict=alcohol_json)
+        # 毎回「平均杯数」と「合計売上」を計算するのではなく、選択に応じて準備しておくことで効率化
+        df_val = getByProductDf.df_all_num if option_daily == "平均杯数" else getByProductDf.df_all_sale
+        df_dict = getByProductDf.json_to_df_dict(df_all=df_val, json_dict=alcohol_json)
+        df_data = alcoholAnalysisUtils.prepare_alcohol_df_num(df_dict).reset_index()
         
-        df_alcohol_num = alcoholAnalysisUtils.prepare_alcohol_df_num(df_val_num_dict)
-        df_alcohol_num = df_alcohol_num.reset_index()
-        df_alcohol_sale = alcoholAnalysisUtils.prepare_alcohol_df_num(df_val_sale_dict)
-        df_alcohol_sale = df_alcohol_sale.reset_index()
-        
+        # ifの入れ子構造がなくなり、簡潔に
         if option_alcohol == "アルコール合計":
-            if option_daily == "平均杯数":
-                data = alcoholAnalysisUtils.get_alchol_data(df_alcohol_num)
-                alcoholAnalysisCharts.alchol_graph(data)
-            else: #
-                data = alcoholAnalysisUtils.get_alchol_data(df_alcohol_sale)
-                alcoholAnalysisCharts.alchol_graph(data)
+            alcoholAnalysisCharts.alchol_graph(alcoholAnalysisUtils.get_alchol_data(df_data))
         elif option_alcohol == "ビール":
-            if option_daily == "平均杯数":
-                data = alcoholAnalysisUtils.get_beer_data(df_alcohol_num)
-                alcoholAnalysisCharts.beer_graph(data)
-            else:
-                data = alcoholAnalysisUtils.get_beer_data(df_alcohol_sale)
-                alcoholAnalysisCharts.beer_graph(data)
+            alcoholAnalysisCharts.beer_graph(alcoholAnalysisUtils.get_beer_data(df_data))
         elif option_alcohol == "秋鹿":
-            if option_daily == "平均杯数":
-                #データの読み込み
-                data = alcoholAnalysisUtils.get_akishika_data(df_alcohol_num)
-                alcoholAnalysisCharts.akishika_graph(data)
-            else:
-                # データの読み込み
-                data = alcoholAnalysisUtils.get_akishika_data(df_alcohol_sale)
-                alcoholAnalysisCharts.akishika_graph(data)
+            alcoholAnalysisCharts.akishika_graph(alcoholAnalysisUtils.get_akishika_data(df_data))
         else: # 若尾ワイン
-            if option_daily == "平均杯数":
-                # データの読み込み
-                data = alcoholAnalysisUtils.get_wine_data(df_alcohol_num)
-                alcoholAnalysisCharts.wine_graph(data)
-            else:
-                # データの読み込み
-                data = alcoholAnalysisUtils.get_wine_data(df_alcohol_sale)
-                alcoholAnalysisCharts.wine_graph(data)
+            alcoholAnalysisCharts.wine_graph(alcoholAnalysisUtils.get_wine_data(df_data))
     except Exception as e:
         st.error(f"エラーが発生しました: {e}")

--- a/src/components/utils/DinerAnalysisUtils.py
+++ b/src/components/utils/DinerAnalysisUtils.py
@@ -1,0 +1,101 @@
+from matplotlib import pyplot as plt
+import pandas as pd
+import numpy as np
+from datetime import datetime, date, timedelta
+from dateutil.relativedelta import relativedelta
+import japanize_matplotlib
+from oauth2client.service_account import ServiceAccountCredentials
+import streamlit as st
+import src.components.utils.SpreadSheets as SpreadSheets
+japanize_matplotlib.japanize()
+
+class DinerAnalysisUtils:
+    def summarize_diner_sales(self, df: pd.DataFrame, date: str) -> pd.Series:
+        """
+        指定した年と月の各商品の合計販売数を表示する関数
+        """
+        year = int(date[:4])
+        month = int(date.split('_')[1])
+
+        if not pd.api.types.is_datetime64_any_dtype(df.index):
+            df.index = pd.to_datetime(df.index)
+        target_df = df[(df.index.year == year) & (df.index.month == month)]
+        target_df = target_df.apply(pd.to_numeric, errors='coerce')
+        filtered_df = target_df.dropna(axis=1, how='all')
+        numeric_df = filtered_df.select_dtypes(include=["number"])
+        if numeric_df.empty:
+            print(f"No numeric data found for {year}-{month}")
+        
+        summary = numeric_df.sum()
+        
+        return summary
+
+        
+    def get_month_list(self):
+        now = datetime.now() - relativedelta(months=1)
+        current_year = now.year
+        current_month = now.month
+
+        def generate_month_list(start_year, start_month, end_year, end_month):
+            start_date = datetime(start_year, start_month, 1)
+            end_date = datetime(end_year, end_month, 1)
+            month_list = []
+
+            while start_date <= end_date:
+                # 月の部分に先頭のゼロを付けないフォーマットを使用
+                month_list.append(f"{start_date.year}_{start_date.month}")
+                start_date += timedelta(days=31)
+                start_date = start_date.replace(day=1)
+
+            return month_list
+
+        month_list = generate_month_list(2022, 10, current_year, current_month)
+        return month_list
+    
+    def prepare_diner_df_num(self, df_dict: dict) -> pd.DataFrame:
+        """
+        カテゴリ別に集計済みのDataFrame辞書から、日々の売上合計を算出して
+        一つのDataFrameにまとめる関数。
+        """
+        diner_keys = self.__get_diner_list()
+        
+        diner_series_list = []
+        for key in diner_keys:
+            if key in df_dict:
+                series_sum = df_dict[key].sum(axis=1).rename(key)
+                diner_series_list.append(series_sum)
+            else:
+                # データがないカテゴリについては警告を出す（任意）
+                print(f"Warning: Category '{key}' not found in df_dict")
+
+        # データが一つもなかった場合は、空のDataFrameを返す
+        if not diner_series_list:
+            return pd.DataFrame()
+
+        # リストに格納したすべてのSeriesを一度に連結する
+        diner_df = pd.concat(diner_series_list, axis=1)
+        
+        # NaN（対象の日に売上がなかった商品など）を0で埋める
+        diner_df = diner_df.fillna(0)
+
+        return diner_df
+
+    
+    def __get_diner_list(self):
+        diner_list = [
+            "白味噌",
+            "赤味噌",
+            "辛味噌",
+            "TOYONO",
+            "つけ麺8号",
+            "担々麺",
+            "ベジ味噌",
+            "焦がし味噌北海道",
+            "あさりと味噌",
+            "イカスミ",
+            "つけ麺6号",
+            "海老味噌カリー",
+            "油そば",
+            "和え玉"
+        ]
+        return diner_list

--- a/src/components/utils/GetByProductDf.py
+++ b/src/components/utils/GetByProductDf.py
@@ -6,7 +6,7 @@ japanize_matplotlib.japanize()
 
 class GetByProductDf:
     def __init__(self):
-        self.df_all_val = self.get_all_val_num()
+        self.df_all_num = self.get_all_val_num()
         self.df_all_sale = self.get_all_val_sale()
 
     def get_all_val_num(

--- a/src/components/utils/MidnightAnalysisUtils.py
+++ b/src/components/utils/MidnightAnalysisUtils.py
@@ -1,0 +1,93 @@
+from matplotlib import pyplot as plt
+import pandas as pd
+import numpy as np
+from datetime import datetime, date, timedelta
+from dateutil.relativedelta import relativedelta
+import japanize_matplotlib
+from oauth2client.service_account import ServiceAccountCredentials
+import streamlit as st
+import src.components.utils.SpreadSheets as SpreadSheets
+japanize_matplotlib.japanize()
+
+class MidnightAnalysisUtils:
+    def summarize_midnight_sales(self, df: pd.DataFrame, date: str) -> pd.Series:
+        """
+        指定した年と月の各商品の合計販売数を表示する関数
+        """
+        year = int(date[:4])
+        month = int(date.split('_')[1])
+
+        if not pd.api.types.is_datetime64_any_dtype(df.index):
+            df.index = pd.to_datetime(df.index)
+        target_df = df[(df.index.year == year) & (df.index.month == month)]
+        target_df = target_df.apply(pd.to_numeric, errors='coerce')
+        filtered_df = target_df.dropna(axis=1, how='all')
+        numeric_df = filtered_df.select_dtypes(include=["number"])
+        if numeric_df.empty:
+            print(f"No numeric data found for {year}-{month}")
+        
+        summary = numeric_df.sum()
+        
+        return summary
+
+        
+    def get_month_list(self):
+        now = datetime.now() - relativedelta(months=1)
+        current_year = now.year
+        current_month = now.month
+
+        def generate_month_list(start_year, start_month, end_year, end_month):
+            start_date = datetime(start_year, start_month, 1)
+            end_date = datetime(end_year, end_month, 1)
+            month_list = []
+
+            while start_date <= end_date:
+                # 月の部分に先頭のゼロを付けないフォーマットを使用
+                month_list.append(f"{start_date.year}_{start_date.month}")
+                start_date += timedelta(days=31)
+                start_date = start_date.replace(day=1)
+
+            return month_list
+
+        month_list = generate_month_list(2022, 10, current_year, current_month)
+        return month_list
+    
+    def prepare_midnight_df_num(self, df_dict: dict) -> pd.DataFrame:
+        """
+        カテゴリ別に集計済みのDataFrame辞書から、日々の売上合計を算出して
+        一つのDataFrameにまとめる関数。
+        """
+        midnight_keys = self.__get_midnight_list()
+        
+        midnight_series_list = []
+        for key in midnight_keys:
+            if key in df_dict:
+                series_sum = df_dict[key].sum(axis=1).rename(key)
+                midnight_series_list.append(series_sum)
+            else:
+                # データがないカテゴリについては警告を出す（任意）
+                print(f"Warning: Category '{key}' not found in df_dict")
+
+        # データが一つもなかった場合は、空のDataFrameを返す
+        if not midnight_series_list:
+            return pd.DataFrame()
+
+        # リストに格納したすべてのSeriesを一度に連結する
+        midnight_df = pd.concat(midnight_series_list, axis=1)
+        
+        # NaN（対象の日に売上がなかった商品など）を0で埋める
+        midnight_df = midnight_df.fillna(0)
+
+        return midnight_df
+
+    
+    def __get_midnight_list(self):
+        midnight_list = [
+            "つけ麺8号",
+            "白味噌",
+            "赤味噌",
+            "辛味噌",
+            "油そば",
+            "つけ麺6号"
+        ]
+        return midnight_list


### PR DESCRIPTION
## 概要
Streamlit上でラーメン分析・ランチ分析機能を実装しました。

---

## 背景・目的
メニューの廃止・継続判断を行うための分析基盤が必要でした。売上・販売数の可視化により、各メニューの実績を直感的に把握できるようにします。

---

## 変更内容

### 🍜 ラーメン分析（`RamenAnalysisCharts.py`）
「販売数」と「売上」でグラフ表示を変更可能に
  タイムゾーン別フィルタリング・月範囲フィルタに対応

- **昼・夜・深夜・全体ごとのラーメン**を円グラフで可視化
  - メニュー共通カラーマップで視認性を統一
  - 凡例とグラフの文字の重なりを修正
  - グラフの文字を横文字に統一
  - 円グラフを触ると、売上や杯数がみれるように
- **曜日ごとのラーメン**を棒グラフで表示
  - 昼・夜・深夜・全体の切り替えに対応
  - 水〜日の営業曜日に絞った表示
  - 棒グラフを触ると、売上や杯数がみれるように

### 🥗 ランチ分析（`LunchAnalysisCharts.py`）
「販売数」と「売上」でグラフ表示を変更可能に

- **昼カテゴリ別**を円グラフで可視化
  - ラーメン系・唐揚げプレート・発酵御膳・キッズ等をカテゴリ別に集計
  - グラフの文字を横文字に統一
- **セットメニューの内訳**を円グラフで表示
  - セット・ラーメンセットを品目ごとに分解